### PR TITLE
eldap-wrapper is useless now that Erlang R16B is required

### DIFF
--- a/package.mk
+++ b/package.mk
@@ -1,5 +1,5 @@
 RELEASABLE:=true
-DEPS:=rabbitmq-server rabbitmq-erlang-client eldap-wrapper
+DEPS:=rabbitmq-server rabbitmq-erlang-client
 
 ifeq ($(shell nc -z localhost 389 && echo true),true)
 WITH_BROKER_TEST_COMMANDS:=eunit:test([rabbit_auth_backend_ldap_unit_test,rabbit_auth_backend_ldap_test],[verbose])


### PR DESCRIPTION
Fixes #10.
