### PR TITLE
Adapt to rabbitmq-server#345

### DIFF
--- a/etc/rabbit-test.config
+++ b/etc/rabbit-test.config
@@ -36,6 +36,8 @@
                          {'not', {equals, "${username}", "Mike Bridgen"}}]}
                       ]}}
                    ]}}
-            ]}}
+            ]}},
+    {tag_queries, [{administrator, {constant, false}},
+                   {management,    {constant, false}}]}
   ]}
 ].

--- a/etc/rabbit-test.config
+++ b/etc/rabbit-test.config
@@ -1,6 +1,5 @@
 %% -*- erlang -*-
-[{rabbit, [{auth_backends, [rabbit_auth_backend_ldap]},
-           {default_vhost, <<"test">>}]},
+[{rabbit, [{default_vhost, <<"test">>}]},
  {rabbitmq_auth_backend_ldap,
   [ {servers,            ["localhost"]},
     {user_dn_pattern,    "cn=${username},ou=People,dc=example,dc=com"},

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -70,8 +70,8 @@ user_login_authentication(Username, AuthProps) ->
 
 user_login_authorization(Username) ->
     case user_login_authentication(Username, []) of
-        {ok, #auth_user{impl = Impl}} -> {ok, Impl};
-        Else                          -> Else
+        {ok, #auth_user{impl = Impl, tags = Tags}} -> {ok, Impl, Tags};
+        Else                                       -> Else
     end.
 
 check_vhost_access(User = #auth_user{username = Username,

--- a/test/src/rabbit_auth_backend_ldap_test.erl
+++ b/test/src/rabbit_auth_backend_ldap_test.erl
@@ -188,9 +188,9 @@ permission_match() ->
                  #'queue.declare'{queue = <<"prefix-test">>},
                  #'queue.bind'{exchange = N, queue = <<"prefix-test">>}]
         end,
-    test_resource_funs([{?SIMON, B(<<"prefix-abc123">>), ok},
+    test_resource_funs([{?SIMON, B(<<"prefix-abc123">>),              ok},
                         {?SIMON, B(<<"abc123">>),                     fail},
-                        {?SIMON, B(<<"xch-Simon MacMullen-abc123">>),    fail}]).
+                        {?SIMON, B(<<"xch-Simon MacMullen-abc123">>), fail}]).
 
 tag_check(Tags) ->
     fun() ->


### PR DESCRIPTION
Fix for issue https://github.com/rabbitmq/rabbitmq-server/issues/338

Have the authorisation code propagate tags into the user record. Also add tests for the change.

A set of related changes to the rabbitmq-server handle the extra tags returned here. See https://github.com/rabbitmq/rabbitmq-server/pull/345
