### PR TITLE
Improve Configuration File & Test a Little More

### DIFF
--- a/etc/rabbit-test.config
+++ b/etc/rabbit-test.config
@@ -36,7 +36,8 @@
                       ]}}
                    ]}}
             ]}},
-    {tag_queries, [{administrator, {constant, false}},
+    {tag_queries, [{monitor,       {constant, true}},
+                   {administrator, {constant, false}},
                    {management,    {constant, false}}]}
   ]}
 ].

--- a/etc/rabbit-test.config
+++ b/etc/rabbit-test.config
@@ -7,7 +7,6 @@
     {use_ssl,            false},
     {port,               389},
     {log,                true},
-    {tag_queries,        [{administrator, {constant, false}}]},
     {vhost_access_query, {exists, "ou=${vhost},ou=vhosts,dc=example,dc=com"}},
     {resource_access_query,
      {for, [{resource, exchange,

--- a/test/src/rabbit_auth_backend_ldap_test.erl
+++ b/test/src/rabbit_auth_backend_ldap_test.erl
@@ -43,7 +43,7 @@ ldap_only_test_() ->
         {"LDAP Constant", const()},
         {"LDAP String match", string_match()},
         {"LDAP Boolean check", boolean_logic()},
-        {"LDAP Tags", tag_check([])}
+        {"LDAP Tags", tag_check([monitor])}
     ]}.
 
 ldap_and_internal_test_() ->
@@ -64,7 +64,7 @@ ldap_and_internal_test_() ->
       end,
       [ {"LDAP&Internal Login", login()},
         {"LDAP&Internal Permissions", permission_match()},
-        {"LDAP&Internal Tags", tag_check([management, foo])}
+        {"LDAP&Internal Tags", tag_check([monitor, management, foo])}
     ]}.
 
 internal_followed_ldap_and_internal_test_() ->
@@ -85,7 +85,7 @@ internal_followed_ldap_and_internal_test_() ->
       end,
       [ {"Internal, LDAP&Internal Login", login()},
         {"Internal, LDAP&Internal Permissions", permission_match()},
-        {"Internal, LDAP&Internal Tags", tag_check([management, foo])}
+        {"Internal, LDAP&Internal Tags", tag_check([monitor, management, foo])}
     ]}.
 
 


### PR DESCRIPTION
Two changes around tagged queries for ticket https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/issues/24:
1. Delete a misleading entry from the configuration file for the test-suite.
2. Add a tagged query to the configuration, one which is always true, then test for it's presence in the test-suite. Previously, we'd test only the absence of tags specified with the LDAP plugin, i.e. those which are always false.
