### PR TITLE
A single failing tag query no longer makes all tag attribution fail

### DIFF
--- a/etc/rabbit-test.config
+++ b/etc/rabbit-test.config
@@ -38,6 +38,7 @@
             ]}},
     {tag_queries, [{monitor,       {constant, true}},
                    {administrator, {constant, false}},
-                   {management,    {constant, false}}]}
+                   {management,
+                    {exists, "cn=${username},ou=Faculty,dc=Computer Science,dc=Engineering"}}]}
   ]}
 ].

--- a/etc/rabbit-test.config
+++ b/etc/rabbit-test.config
@@ -38,7 +38,6 @@
             ]}},
     {tag_queries, [{monitor,       {constant, true}},
                    {administrator, {constant, false}},
-                   {management,
-                    {exists, "cn=${username},ou=Faculty,dc=Computer Science,dc=Engineering"}}]}
+                   {management,    {constant, false}}]}
   ]}
 ].

--- a/example/people.ldif
+++ b/example/people.ldif
@@ -35,6 +35,12 @@ cn: Charlie
 sn: Charlie Boy
 userPassword: password
 
+dn: cn=Edward,ou=people,dc=example,dc=com
+objectClass: person
+cn: Edward
+sn: Ed
+userPassword: password
+
 dn: cn=John Doe,ou=people,dc=example,dc=com
 objectClass: person
 cn: John Doe

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -386,11 +386,7 @@ do_login(Username, PrebindUserDN, Password, LDAP) ->
                  _       -> with_ldap(creds(User), DTQ)
              end,
     case TagRes of
-        {ok, L} -> case [E || {_, E = {error, _}} <- L] of
-                       []      -> Tags = [Tag || {Tag, true} <- L],
-                                  {ok, User#auth_user{tags = Tags}};
-                       [E | _] -> E
-                   end;
+        {ok, L} -> {ok, User#auth_user{tags = [Tag || {Tag, true} <- L]}};
         E       -> E
     end.
 

--- a/test/src/rabbit_auth_backend_ldap_test.erl
+++ b/test/src/rabbit_auth_backend_ldap_test.erl
@@ -89,64 +89,60 @@ internal_followed_ldap_and_internal_test_() ->
     ]}.
 
 tag_attribution_test_() ->
-    [{setup,
-      fun () ->
-          ok = application:set_env(rabbit, auth_backends, Cfg),
-          Setup()
+    {setup,
+     fun () ->
+             Cfg = case application:get_env(rabbit_auth_backend_ldap, tag_queries) of
+                       undefined -> undefined;
+                       {ok, X} -> X
+                   end,
+             set_env(tag_query_configuration()),
+             Cfg
+     end,
+     fun (undefined) ->
+             ok;
+         (Cfg) ->
+             ok = application:set_env(rabbit_auth_backend_ldap, tag_queries, Cfg)
+     end,
+     {foreachx,
+      fun (ldap_only) ->
+              ok = application:set_env(rabbit, auth_backends, [rabbit_auth_backend_ldap]);
+          (ldap_and_internal) ->
+              ok = application:set_env(rabbit, auth_backends,
+                  [{rabbit_auth_backend_ldap, rabbit_auth_backend_internal}]),
+              internal_authorization_setup();
+          (internal_followed_by_ldap_and_internal) ->
+              ok = application:set_env(rabbit, auth_backends,
+                  [rabbit_auth_backend_internal,
+                   {rabbit_auth_backend_ldap, rabbit_auth_backend_internal}]),
+              internal_authorization_setup()
       end,
-      fun (_) ->
-          Teardown(),
-          ok = application:unset_env(rabbit, auth_backends)
+      fun (ldap_only, _) ->
+              ok = application:unset_env(rabbit, auth_backends);
+          (BackendCfg, _) when BackendCfg == ldap_and_internal;
+                               BackendCfg == internal_followed_by_ldap_and_internal ->
+              internal_authorization_teardown(),
+              ok = application:unset_env(rabbit, auth_backends)
       end,
-      [ { %% Test that the user is attributed all the tags for which the
-          %% corresponding query should succeed.
-          "LDAP Tag attribution", tag_check(<<"Edward">>, <<"password">>, [monitor, normal])}]
-     } || {Cfg, Setup, Teardown} <- lists:zip3(backend_configuration(),
-          authorization_setup(), authorization_teardown())].
-
-backend_configuration() ->
-    [[rabbit_auth_backend_ldap],
-     [{rabbit_auth_backend_ldap, rabbit_auth_backend_internal}],
-     [rabbit_auth_backend_internal, {rabbit_auth_backend_ldap, rabbit_auth_backend_internal}]].
-
-authorization_setup() ->
-    [fun ldap_authorization_setup/0,
-     fun internal_authorization_setup/0,
-     fun internal_authorization_setup/0].
-
-authorization_teardown() ->
-    [fun ldap_authorization_teardown/0,
-     fun internal_authorization_teardown/0,
-     fun internal_authorization_teardown/0].
-
-ldap_authorization_setup() ->
-    set_env(tag_query_configuration()).
-
-ldap_authorization_teardown() ->
-    set_env(base_login_env()).
-
-tag_query_configuration() ->
-    [{tag_queries,
-      [{administrator, {constant, false}},
-       %% Query result for tag `management` is FALSE
-       %% because this object does NOT exist.
-       {management,
-        {exists, "cn=${username},ou=Faculty,dc=Computer Science,dc=Engineering"}},
-       {monitor, {constant, true}},
-       %% Query result for tag `normal` is TRUE because
-       %% this object exists.
-       {normal,
-        {exists, "cn=${username},ou=people,dc=example,dc=com"}}]}].
-
-internal_authorization_setup() ->
-    ok = control_action(add_user, ["Edward", ""]),
-    ok = control_action(set_user_tags, ["Edward"] ++ internal_authorization_tags()).
-
-internal_authorization_teardown() ->
-    ok = control_action(delete_user, ["Edward"]).
-
-internal_authorization_tags() ->
-    [].
+      [{ldap_only,
+        fun(_, _) ->
+                {"LDAP Tag attribution",
+                 tag_check(<<"Edward">>, <<"password">>, [monitor, normal])}
+        end},
+       {ldap_and_internal,
+        fun(_, _) ->
+                {"LDAP & Internal Tag attribution",
+                 tag_check(<<"Edward">>, <<"password">>,
+                           [monitor, normal] ++ internal_authorization_tags())}
+        end},
+       {internal_followed_by_ldap_and_internal,
+        fun(_, _) ->
+                {"Internal followed by LDAP & Internal Tag attribution",
+                 tag_check(<<"Edward">>, <<"password">>,
+                           [monitor, normal] ++ internal_authorization_tags())}
+        end}
+      ]
+     }
+    }.
 
 %%--------------------------------------------------------------------
 
@@ -267,6 +263,31 @@ tag_check(Username, Password, Tags)
                            Username, Password),
             ?assertEqual(Tags, User#user.tags)
     end.
+
+
+tag_query_configuration() ->
+    [{tag_queries,
+      [{administrator, {constant, false}},
+       %% Query result for tag `management` is FALSE
+       %% because this object does NOT exist.
+       {management,
+        {exists, "cn=${username},ou=Faculty,dc=Computer Science,dc=Engineering"}},
+       {monitor, {constant, true}},
+       %% Query result for tag `normal` is TRUE because
+       %% this object exists.
+       {normal,
+        {exists, "cn=${username},ou=people,dc=example,dc=com"}}]}].
+
+internal_authorization_setup() ->
+    ok = control_action(add_user, ["Edward", ""]),
+    ok = control_action(set_user_tags, ["Edward"] ++
+        [ atom_to_list(T) || T <- internal_authorization_tags() ]).
+
+internal_authorization_teardown() ->
+    ok = control_action(delete_user, ["Edward"]).
+
+internal_authorization_tags() ->
+    [foo, bar].
 
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
Discussion can be found on the [ticket](https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/issues/15#issue-103569940).
