### PR TITLE
Bumps up default LDAP connection worker pool size to 64.

### DIFF
--- a/src/rabbitmq_auth_backend_ldap.app.src
+++ b/src/rabbitmq_auth_backend_ldap.app.src
@@ -20,5 +20,5 @@
           {port,                  389},
           {timeout,               infinity},
           {log,                   false},
-          {pool_size,             10} ] },
+          {pool_size,             64} ] },
   {applications, [kernel, stdlib, eldap, rabbit]}]}.


### PR DESCRIPTION
64, as per [recommendation](https://github.com/rabbitmq/rabbitmq-server/issues/780#issuecomment-215644372).

Fixes #35. 
