### PR TITLE
Workaround for closing already closed ldap connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ otp_release:
   - "R16B03-1"
   - "17.5"
   - "18.0"
+  - "18.1"
+  - "18.2"
+  - "18.3"
 
 # The checkout made by Travis is a "detached HEAD". We switch back
 # to a tag or a branch. This pleases our git_rmq fetch method in

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -306,8 +306,9 @@ with_ldap({ok, Creds}, Fun, Servers) ->
               case with_login(Creds, Servers, Opts, Fun) of
                   {error, {gen_tcp_error, closed}} ->
                       %% retry with new connection
-                      ?L1("server closed connection", []),
+                      rabbit_log:warning("LDAP server closed connection."),
                       purge_conn(Creds == anon, Servers, Opts),
+                      rabbit_log:warning("LDAP retrying with new connection."),
                       with_login(Creds, Servers, Opts, Fun);
                   Result -> Result
               end
@@ -384,7 +385,7 @@ purge_conn(IsAnon, Servers, Opts) ->
     Conns = get(ldap_conns),
     Key = {IsAnon, Servers, Opts},
     {_, {_, Conn}} = dict:find(Key, Conns),
-    ?L1("Purging an already closed LDAP server connection", []),
+    rabbit_log:warning("LDAP Purging an already closed LDAP server connection"),
     % We cannot close the connection with eldap:close/1 because as of OTP-13327
     % eldap will try to do_unbind first and will fail with a `{gen_tcp_error, closed}`.
     % Since we know that the connection is already closed, we just

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -306,9 +306,9 @@ with_ldap({ok, Creds}, Fun, Servers) ->
               case with_login(Creds, Servers, Opts, Fun) of
                   {error, {gen_tcp_error, closed}} ->
                       %% retry with new connection
-                      rabbit_log:warning("LDAP server closed connection."),
+                      rabbit_log:warning("TCP connection to a LDAP server is already closed."),
                       purge_conn(Creds == anon, Servers, Opts),
-                      rabbit_log:warning("LDAP retrying with new connection."),
+                      rabbit_log:warning("LDAP will retry with a new connection."),
                       with_login(Creds, Servers, Opts, Fun);
                   Result -> Result
               end

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -384,11 +384,11 @@ purge_conn(IsAnon, Servers, Opts) ->
     Conns = get(ldap_conns),
     Key = {IsAnon, Servers, Opts},
     {_, {_, Conn}} = dict:find(Key, Conns),
-    ?L1("Purging dead server connection", []),
-    % We cannot close connection with eldap:close because of OTP-13327
-    % eldap will try to do_unbind and will fail with {gen_tcp_error, closed}
+    ?L1("Purging an already closed LDAP server connection", []),
+    % We cannot close the connection with eldap:close/1 because as of OTP-13327
+    % eldap will try to do_unbind first and will fail with a `{gen_tcp_error, closed}`.
     % Since we know that the connection is already closed, we just
-    % kill the handle process.
+    % kill its process.
     unlink(Conn),
     exit(Conn, closed),
     put(ldap_conns, dict:erase(Key, Conns)).


### PR DESCRIPTION
Fixes #41
Workaround and issue caused by an [OTP-18.3 regression](https://github.com/erlang/otp/commit/761804cdda45a71b9e82e5340ca98c3ea94e4886).
