### PR TITLE
Recursive search for parent groups

### DIFF
--- a/etc/rabbit-test.config
+++ b/etc/rabbit-test.config
@@ -7,6 +7,7 @@
     {use_ssl,            false},
     {port,               389},
     {log,                true},
+    {group_lookup_base,  "ou=groups,dc=example,dc=com"},
     {vhost_access_query, {exists, "ou=${vhost},ou=vhosts,dc=example,dc=com"}},
     {resource_access_query,
      {for, [{resource, exchange,

--- a/example/groups.ldif
+++ b/example/groups.ldif
@@ -23,3 +23,19 @@ cn: people
 member: cn=Charlie,ou=people,dc=example,dc=com
 member: cn=Dominic,ou=people,dc=example,dc=com
 member: uid=peter,ou=people,dc=example,dc=com
+
+dn: cn=bobs,ou=groups,dc=example,dc=com
+objectclass: groupOfNames
+cn: bobs
+member: cn=Bob,ou=people,dc=example,dc=com
+
+dn: cn=bobs2,ou=groups,dc=example,dc=com
+objectclass: groupOfNames
+cn: bobs2
+member: cn=bobs,ou=groups,dc=example,dc=com
+
+dn: cn=admins,ou=groups,dc=example,dc=com
+objectclass: groupOfNames
+cn: admins
+member: cn=bobs2,ou=groups,dc=example,dc=com
+member: cn=wheel,ou=groups,dc=example,dc=com

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -146,6 +146,15 @@ evaluate0({in_group, DNPattern, Desc}, Args,
     ?L1("evaluated in_group for \"~s\": ~p", [DN, R]),
     R;
 
+evaluate0({in_group_recursive, DNPattern, Desc}, Args,
+          #auth_user{impl = #impl{user_dn = UserDN}}, LDAP) ->
+    GroupsBase = case env(groups_lookup_base) of
+        none -> env(dn_lookup_base)};
+        B    -> B
+    end,
+    GroupDN = fill(DNPattern, Args),
+    search_recursively(LDAP, Desc, GroupsBase, CurrentDN, TargetDN, []);
+
 evaluate0({'not', SubQuery}, Args, User, LDAP) ->
     R = evaluate(SubQuery, Args, User, LDAP),
     ?L1("negated result to ~s", [R]),
@@ -202,6 +211,54 @@ evaluate0({attribute, DNPattern, AttributeName}, Args, _User, LDAP) ->
 
 evaluate0(Q, Args, _User, _LDAP) ->
     {error, {unrecognised_query, Q, Args}}.
+
+search_recursively(LDAP, Desc, GroupsBase, CurrentDN, TargetDN, Path) ->
+    case lists:member(CurrentDN, Path) of
+        true  ->
+            ?L("recursive cycle on DN ~s while searching for group ~s",
+               [CurrentDN, TargetDN]),
+            false;
+        false ->
+            Filter = eldap:equalityMatch(Desc, CurrentDN),
+            case eldap:search(LDAP,
+                      [{base, GroupsBase},
+                       {filter, Filter},
+                       {attributes, ["dn"]},
+                       {scope, eldap:wholeSubtree()}]) of
+            {error, _} = E ->
+                ?L("error searching for parent groups for \"~s\": ~p",
+                    [CurrentDN, E]),
+                false;
+            {ok, #eldap_search_result{entries = []}} ->
+                false;
+            {ok, #eldap_search_result{entries = Entries}} ->
+                DNs = [ DN || #eldap_entry{object_name = DN} <- Entries ];
+                case lists:member(TargetDN, DNs) of
+                    true  ->
+                        true;
+                    false ->
+                        NextPath = [CurrentDN | Path],
+                        lists:any(fun(DN) ->
+                            search_recursively(LDAP, Desc, DN, TargetDN, NextPath)
+                        end,
+                        DNs)
+                end
+            end.
+            % case attribute(CurrentDN, Desc, LDAP) of
+            %     {error, _} = E -> E;
+            %     []             -> false;
+            %     Attributes     ->
+            %         case lists:member(TargetDN, Attributes) of
+            %             true  -> true;
+            %             false ->
+            %                 NextPath = [CurrentDN | Path],
+            %                 lists:any(fun(DN) ->
+            %                     search_recursively(LDAP, Desc, DN, TargetDN, NextPath)
+            %                 end,
+            %                 Attributes)
+            %         end
+            % end
+    end.
 
 safe_eval(_F, {error, _}, _)          -> false;
 safe_eval(_F, _,          {error, _}) -> false;

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -159,10 +159,14 @@ evaluate0({in_group_nested, DNPattern, Desc, Scope}, Args,
         B    -> B
     end,
     GroupDN = fill(DNPattern, Args),
-    EldapScope = case Scope of
-        subtree  -> eldap:wholeSubtree();
-        onelevel -> eldap:singleLevel()
-    end,
+    EldapScope =
+        case Scope of
+            subtree      -> eldap:wholeSubtree();
+            singlelevel  -> eldap:singleLevel();
+            single_level -> eldap:singleLevel();
+            onelevel     -> eldap:singleLevel();
+            one_level    -> eldap:singleLevel()
+        end,
     search_nested_group(LDAP, Desc, GroupsBase, EldapScope, UserDN, GroupDN, []);
 
 evaluate0({'not', SubQuery}, Args, User, LDAP) ->
@@ -235,7 +239,7 @@ search_groups(LDAP, Desc, GroupsBase, Scope, DN) ->
         {ok, #eldap_search_result{entries = []}} ->
             [];
         {ok, #eldap_search_result{entries = Entries}} ->
-            [ DN || #eldap_entry{object_name = DN} <- Entries ]
+            [ON || #eldap_entry{object_name = ON} <- Entries]
     end.
 
 search_nested_group(LDAP, Desc, GroupsBase, Scope, CurrentDN, TargetDN, Path) ->

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -147,15 +147,23 @@ evaluate0({in_group, DNPattern, Desc}, Args,
     R;
 
 evaluate0({in_group_nested, DNPattern}, Args, User, LDAP) ->
-	evaluate({in_group_nested, DNPattern, "member"}, Args, User, LDAP);
-evaluate0({in_group_nested, DNPattern, Desc}, Args,
+	evaluate({in_group_nested, DNPattern, "member", subtree},
+             Args, User, LDAP);
+evaluate0({in_group_nested, DNPattern, Desc}, Args, User, LDAP) ->
+    evaluate({in_group_nested, DNPattern, Desc, subtree},
+             Args, User, LDAP);
+evaluate0({in_group_nested, DNPattern, Desc, Scope}, Args,
           #auth_user{impl = #impl{user_dn = UserDN}}, LDAP) ->
     GroupsBase = case env(group_lookup_base) of
         none -> env(dn_lookup_base);
         B    -> B
     end,
     GroupDN = fill(DNPattern, Args),
-    search_nested_group(LDAP, Desc, GroupsBase, UserDN, GroupDN, []);
+    EldapScope = case Scope of
+        subtree  -> eldap:wholeSubtree();
+        onelevel -> eldap:singleLevel()
+    end,
+    search_nested_group(LDAP, Desc, GroupsBase, EldapScope, UserDN, GroupDN, []);
 
 evaluate0({'not', SubQuery}, Args, User, LDAP) ->
     R = evaluate(SubQuery, Args, User, LDAP),
@@ -214,13 +222,13 @@ evaluate0({attribute, DNPattern, AttributeName}, Args, _User, LDAP) ->
 evaluate0(Q, Args, _User, _LDAP) ->
     {error, {unrecognised_query, Q, Args}}.
 
-search_groups(LDAP, Desc, GroupsBase, DN) ->
+search_groups(LDAP, Desc, GroupsBase, Scope, DN) ->
     Filter = eldap:equalityMatch(Desc, DN),
     case eldap:search(LDAP,
                       [{base, GroupsBase},
                        {filter, Filter},
                        {attributes, ["dn"]},
-                       {scope, eldap:wholeSubtree()}]) of
+                       {scope, Scope}]) of
         {error, _} = E ->
             ?L("error searching for parent groups for \"~s\": ~p", [DN, E]),
             [];
@@ -230,21 +238,21 @@ search_groups(LDAP, Desc, GroupsBase, DN) ->
             [ DN || #eldap_entry{object_name = DN} <- Entries ]
     end.
 
-search_nested_group(LDAP, Desc, GroupsBase, CurrentDN, TargetDN, Path) ->
+search_nested_group(LDAP, Desc, GroupsBase, Scope, CurrentDN, TargetDN, Path) ->
     case lists:member(CurrentDN, Path) of
         true  ->
             ?L("recursive cycle on DN ~s while searching for group ~s",
                [CurrentDN, TargetDN]),
             false;
         false ->
-            GroupDNs = search_groups(LDAP, Desc, GroupsBase, CurrentDN),
+            GroupDNs = search_groups(LDAP, Desc, GroupsBase, Scope, CurrentDN),
             case lists:member(TargetDN, GroupDNs) of
                 true  ->
                     true;
                 false ->
                     NextPath = [CurrentDN | Path],
                     lists:any(fun(DN) ->
-                        search_nested_group(LDAP, Desc, GroupsBase,
+                        search_nested_group(LDAP, Desc, GroupsBase, Scope,
                                             DN, TargetDN, NextPath)
                     end,
                     GroupDNs)

--- a/src/rabbitmq_auth_backend_ldap.app.src
+++ b/src/rabbitmq_auth_backend_ldap.app.src
@@ -9,6 +9,7 @@
           {user_dn_pattern,       "${username}"},
           {dn_lookup_attribute,   none},
           {dn_lookup_base,        none},
+          {group_lookup_base,     none},
           {dn_lookup_bind,        as_user},
           {other_bind,            as_user},
           {vhost_access_query,    {constant, true}},

--- a/test/src/rabbit_auth_backend_ldap_test.erl
+++ b/test/src/rabbit_auth_backend_ldap_test.erl
@@ -189,7 +189,7 @@ logins_network() ->
      {bad,  [1, 2, 3, 4, 6, 7], ?CAROL, []},
      {good, [5, 6], ?ALICE, []},
      {good, [5, 6], ?BOB, []},
-     {good, [1, 2, 3, 4, 6, 7], ?PETER, []}].
+     {good, [1, 2, 3, 4, 6, 7, 8], ?PETER, []}].
 
 logins_direct() ->
     [{bad,  [5], #amqp_params_direct{}, []},
@@ -208,7 +208,8 @@ login_envs() ->
      {4, {good, other_bind_anon_env()}},
      {5, {good, posix_vhost_access_multiattr_env()}},
      {6, {good, tag_queries_subst_env()}},
-     {7, {bad,  other_bind_broken_env()}}].
+     {7, {bad,  other_bind_broken_env()}},
+     {8, {good, vhost_access_query_nested_groups_env()}}].
 
 base_login_env() ->
     [{user_dn_pattern,     "cn=${username},ou=People,dc=example,dc=com"},
@@ -272,6 +273,9 @@ posix_vhost_access_multiattr_env() ->
                 {string, "cn=people,ou=groups,dc=example,dc=com"},
                 {attribute, "${user_dn}","memberOf"}}
               ]}}].
+
+vhost_access_query_nested_groups_env() ->
+    [{vhost_access_query, {in_group_nested, "cn=admins,ou=groups,dc=example,dc=com"}}].
 
 test_login({N, Env}, Login, FilterList, ResultFun) ->
     case lists:member(N, FilterList) of


### PR DESCRIPTION
Fixes #3 
Introduced new search query `{in_group_nested, TargetDN}` to recursively search for nested groups.
Introduced new environment variable `group_lookup_base` - the base DN for groups. If it's not set, `dn_lookup_base` will be used.

Query will search for all DNs in base directory, that have an attribute `member` (by default) or attribute specified in query. If this DNs don't contain target, they are recursively searched up until no target is found, or there are no parent groups, or cycle is detected.

Restrictions:
- Without base directory query will fail.
- Can be memory consuming if user is in many groups
- Can be time consuming if there is deep group hierarchy

Preferred group structure is tree-based, where groups have many members, but members have few groups.
