### PR TITLE
Hide LDAP errors from clients

### DIFF
--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -470,7 +470,7 @@ with_login(Creds, Servers, Opts, Fun) ->
                             ?L1("bind error: ~s ~p",
                                 [scrub_dn(UserDN, env(log)), E]),
                             %% Do not report internal bind error to a client
-                            {error, ldap_binding_error}
+                            {error, ldap_bind_error}
                     end
             end;
         Error ->
@@ -478,7 +478,7 @@ with_login(Creds, Servers, Opts, Fun) ->
             case Error of
                 {error, {gen_tcp_error, closed}} -> Error;
                 %% Do not report internal connection error to a client
-                _Other                           -> {error, ldap_connection_error}
+                _Other                           -> {error, ldap_connect_error}
             end
     end.
 
@@ -489,7 +489,7 @@ call_ldap_fun(Fun, LDAP, UserDN) ->
     case Fun(LDAP) of
         {error, E} ->
             ?L1("evaluate error: ~s ~p", [scrub_dn(UserDN, env(log)), E]),
-            {error, ldap_evaluation_error};
+            {error, ldap_evaluate_error};
         Other -> Other
     end.
 

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -470,7 +470,7 @@ with_login(Creds, Servers, Opts, Fun) ->
                             ?L1("bind error: ~s ~p",
                                 [scrub_dn(UserDN, env(log)), E]),
                             %% Do not report internal bind error to a client
-                            {error, ldap_bind_error}
+                            {error, ldap_binding_error}
                     end
             end;
         Error ->
@@ -478,7 +478,7 @@ with_login(Creds, Servers, Opts, Fun) ->
             case Error of
                 {error, {gen_tcp_error, closed}} -> Error;
                 %% Do not report internal connection error to a client
-                _Other                           -> {error, ldap_connect_error}
+                _Other                           -> {error, ldap_connection_error}
             end
     end.
 
@@ -489,7 +489,7 @@ call_ldap_fun(Fun, LDAP, UserDN) ->
     case Fun(LDAP) of
         {error, E} ->
             ?L1("evaluate error: ~s ~p", [scrub_dn(UserDN, env(log)), E]),
-            {error, ldap_evaluate_error};
+            {error, ldap_evaluation_error};
         Other -> Other
     end.
 


### PR DESCRIPTION
Related to rabbitmq/rabbitmq-server#1102

LDAP errors are logged to LDAP log,
so we can replace errors with generic messages like
`ldap_connect_error` to be reported to clients.