### PR TITLE
Fix badmatch exception when purging connections

### DIFF
--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -29,6 +29,10 @@
 
 -export([get_connections/0]).
 
+-ifdef(TEST).
+-export([purge_connections/0]).
+-endif.
+
 -define(L(F, A),  log("LDAP "         ++ F, A)).
 -define(L1(F, A), log("    LDAP "     ++ F, A)).
 -define(L2(F, A), log("        LDAP " ++ F, A)).
@@ -42,6 +46,12 @@
 
 get_connections() ->
     worker_pool:submit(ldap_pool, fun() -> get(ldap_conns) end, reuse).
+
+purge_connections() ->
+    [ok = worker_pool:submit(ldap_pool,
+                             fun() -> purge_conn(Anon, Servers, Opts) end, reuse)
+     || {{Anon, Servers, Opts}, _} <- dict:to_list(get_connections())],
+    ok.
 
 user_login_authentication(Username, []) ->
     %% Without password, e.g. EXTERNAL
@@ -517,8 +527,9 @@ is_multi_attr_member(Str1, Str2) ->
 
 purge_conn(IsAnon, Servers, Opts) ->
     Conns = get(ldap_conns),
+    error_logger:info_msg("Conns ~p~n", [Conns]),
     Key = {IsAnon, Servers, Opts},
-    {_, {_, Conn}} = dict:find(Key, Conns),
+    {ok, Conn} = dict:find(Key, Conns),
     rabbit_log:warning("LDAP Purging an already closed LDAP server connection~n"),
     % We cannot close the connection with eldap:close/1 because as of OTP-13327
     % eldap will try to do_unbind first and will fail with a `{gen_tcp_error, closed}`.
@@ -526,7 +537,8 @@ purge_conn(IsAnon, Servers, Opts) ->
     % kill its process.
     unlink(Conn),
     exit(Conn, closed),
-    put(ldap_conns, dict:erase(Key, Conns)).
+    put(ldap_conns, dict:erase(Key, Conns)),
+    ok.
 
 eldap_open(Servers, Opts) ->
     case eldap:open(Servers, ssl_conf() ++ Opts) of

--- a/src/rabbit_auth_backend_ldap_app.erl
+++ b/src/rabbit_auth_backend_ldap_app.erl
@@ -25,7 +25,7 @@
 
 -rabbit_boot_step({ldap_pool,
                    [{description, "LDAP pool"},
-                    {mfa, {?MODULE, create_ldap_pool, []}}, 
+                    {mfa, {?MODULE, create_ldap_pool, []}},
                     {requires, kernel_ready}]}).
 
 create_ldap_pool() ->
@@ -43,7 +43,9 @@ start(_Type, _StartArgs) ->
     {ok, SSL} = application:get_env(rabbitmq_auth_backend_ldap, use_ssl),
     {ok, TLS} = application:get_env(rabbitmq_auth_backend_ldap, use_starttls),
     case SSL orelse TLS of
-        true  -> rabbit_networking:ensure_ssl();
+        true  ->
+            rabbit_networking:ensure_ssl(),
+            ok;
         false -> ok
     end,
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -101,6 +101,7 @@ all() ->
 
 groups() ->
     Tests = [
+        purge_connection,
         ldap_only,
         ldap_and_internal,
         internal_followed_ldap_and_internal,
@@ -240,6 +241,16 @@ end_per_testcase(Testcase, Config) ->
 %% -------------------------------------------------------------------
 %% Testsuite cases
 %% -------------------------------------------------------------------
+
+purge_connection(Config) ->
+    {ok, _} = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                           rabbit_auth_backend_ldap,
+                                           user_login_authentication,
+                                           [<<?ALICE_NAME>>, []]),
+
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                      rabbit_auth_backend_ldap,
+                                      purge_connections, []).
 
 connections_closed_after_timeout(Config) ->
     {ok, _} = rabbit_ct_broker_helpers:rpc(Config, 0,


### PR DESCRIPTION
The exception stops timed out connections from
reconnecting successfully.

[#144015233]

Fixes #66