### PR TITLE
Allow anonymous authentication (false by default)

### DIFF
--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -418,7 +418,8 @@ with_ldap({error, _} = E, _Fun, _State) ->
 %% of interest, so this could still be more efficient.
 with_ldap({ok, Creds}, Fun, Servers) ->
     Opts0 = [{port, env(port)},
-             {idle_timeout, env(idle_timeout)}],
+             {idle_timeout, env(idle_timeout)},
+             {anon_auth, true}],
     Opts1 = case env(log) of
                 network ->
                     Pre = "    LDAP network traffic: ",


### PR DESCRIPTION
This will allow for anonymous binds for DN lookups. It can be specified
in the configuration by giving an empty string as the username and
password for dn_lookup_bind. Anonymous authentication is disabled by
default.