### PR TITLE
Add option to enable anonymous authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ define PROJECT_ENV
 	    {group_lookup_base,     none},
 	    {dn_lookup_bind,        as_user},
 	    {other_bind,            as_user},
+	    {anon_auth,             false},
 	    {vhost_access_query,    {constant, true}},
 	    {resource_access_query, {constant, true}},
 	    {tag_queries,           [{administrator, {constant, false}}]},

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -389,7 +389,8 @@ with_ldap({error, _} = E, _Fun, _State) ->
 %% of interest, so this could still be more efficient.
 with_ldap({ok, Creds}, Fun, Servers) ->
     Opts0 = [{port, env(port)},
-             {idle_timeout, env(idle_timeout)}],
+             {idle_timeout, env(idle_timeout)},
+             {anon_auth, env(anon_auth)}],
     Opts1 = case env(log) of
                 network ->
                     Pre = "    LDAP network traffic: ",


### PR DESCRIPTION
This will allow the user to enable the anon_auth flag in eldap in order
to be able to do a dn lookup by using anonymous authentication instead
of using a dedicated bind user.