### PR TITLE
Handle map when in template arguments

### DIFF
--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -437,7 +437,11 @@ topic_authorisation_consumption1(Config) ->
            {impl,"cn=Bob,ou=People,dc=rabbitmq,dc=com",<<"password">>}
     },
     Resource = #resource{virtual_host = <<"/">>, name = <<"amq.topic">>, kind = topic},
-    Context = #{routing_key => <<"a.b">>},
+    Context = #{routing_key  => <<"a.b">>,
+                variable_map => #{
+                    <<"username">> => <<"guest">>,
+                    <<"vhost">>    => <<"other-vhost">>
+                }},
     %% default is to let pass
     true = rabbit_auth_backend_ldap:check_topic_access(Alice, Resource, read, Context),
 


### PR DESCRIPTION
An Erlang map is turned into several arguments. E.g.
{variable_map, #{username => guest, vhost = some-vhost}} is converted
into 2 arguments: variable_map.username=guest and variable_map.vhost=some-vhost.

Fixes #71