### PR TITLE
Change idle_timeout default to 300 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ define PROJECT_ENV
 	    {timeout,               infinity},
 	    {log,                   false},
 	    {pool_size,             64},
-	    {idle_timeout,          300}
+	    {idle_timeout,          300000}
 	  ]
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ define PROJECT_ENV
 	    {timeout,               infinity},
 	    {log,                   false},
 	    {pool_size,             64},
-	    {idle_timeout,          infinity}
+	    {idle_timeout,          300}
 	  ]
 endef
 

--- a/priv/schema/rabbitmq_auth_backend_ldap.schema
+++ b/priv/schema/rabbitmq_auth_backend_ldap.schema
@@ -70,7 +70,7 @@ end}.
 
 %% LDAP connection inactivity timeout, in milliseconds or 'infinity'
 %%
-%% {idle_timeout, infinity},
+%% {idle_timeout, 300000},
 
 {mapping, "auth_ldap.idle_timeout", "rabbitmq_auth_backend_ldap.idle_timeout",
     [{datatype, [integer, {atom, infinity}]}]}.

--- a/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
@@ -31,11 +31,11 @@
   [rabbitmq_auth_backend_ldap]},
 
  {ldap_timeouts,
-  "auth_ldap.timeout = 50
-   auth_ldap.idle_timeout = 90",
+  "auth_ldap.timeout = 50000
+   auth_ldap.idle_timeout = 90000",
   [{rabbitmq_auth_backend_ldap,[
-                                {timeout, 50},
-                                {idle_timeout, 90}
+                                {timeout, 50000},
+                                {idle_timeout, 90000}
                                ]}],
   [rabbitmq_auth_backend_ldap]},
 


### PR DESCRIPTION
## Proposed Changes

This changes default `idle_timeout` setting to be finite. This means that the client will close
idle connections before the LDAP server in many common cases, thus not leaving connections with socket states the pool currently does not handle well (for that, see #82). It makes sense to have a non-infinite timeout default in general.

See #81 for background.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #81)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #81.

[#155865492]