### PR TITLE
Make it possible to configure group_lookup_base via new style config file

### DIFF
--- a/priv/schema/rabbitmq_auth_backend_ldap.schema
+++ b/priv/schema/rabbitmq_auth_backend_ldap.schema
@@ -185,6 +185,13 @@ end}.
 %% =============
 %%
 
+%% Groups are searched in the DN defined by the `group_lookup_base`
+%% configuration key, or the `dn_lookup_base` variable if
+%% former is `none`.
+
+{mapping, "auth_ldap.group_lookup_base", "rabbitmq_auth_backend_ldap.group_lookup_base",
+    [{datatype, [{enum, [none]}, string]}]}.
+
 %% The LDAP plugin can perform a variety of queries against your
 %% LDAP server to determine questions of authorisation. See
 %% http://www.rabbitmq.com/ldap.html#authorisation for more

--- a/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
@@ -88,6 +88,13 @@
                                ]}],
   [rabbitmq_auth_backend_ldap]},
 
+
+ {group_lookup_base,
+  "auth_ldap.group_lookup_base = DC=gopivotal,DC=com",
+  [{rabbitmq_auth_backend_ldap,
+       [{group_lookup_base, "DC=gopivotal,DC=com"}]}],
+  [rabbitmq_auth_backend_ldap]},
+
  {dn_lookup,
   "auth_ldap.dn_lookup_attribute = userPrincipalName
    auth_ldap.dn_lookup_base = DC=gopivotal,DC=com


### PR DESCRIPTION
## Proposed Changes

This adds `auth_ldap.group_lookup_base` to the Cuttlefish schema. See #85 for justification.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #85.

[#156122704]
