### PR TITLE
Make it possible to configure TLS options via auth_ldap.ssl_options

### DIFF
--- a/priv/schema/rabbitmq_auth_backend_ldap.schema
+++ b/priv/schema/rabbitmq_auth_backend_ldap.schema
@@ -33,20 +33,6 @@ fun(Conf) ->
     end
 end}.
 
-%% Connect to the LDAP server using SSL
-%%
-%% {use_ssl, false},
-
-{mapping, "auth_ldap.use_ssl", "rabbitmq_auth_backend_ldap.use_ssl",
-    [{datatype, {enum, [true, false]}}]}.
-
-%% Connect to the LDAP server using StartTLS
-%%
-%% {use_starttls, false},
-
-{mapping, "auth_ldap.use_starttls", "rabbitmq_auth_backend_ldap.use_starttls",
-    [{datatype, {enum, [true, false]}}]}.
-
 %% Specify the LDAP port to connect to
 %%
 %% {port, 389},
@@ -210,3 +196,131 @@ end}.
 %%
 %% {tag_queries, []}
 %   ]},
+
+%% Connect to the LDAP server using TLS
+%%
+%% {use_ssl, false},
+
+{mapping, "auth_ldap.use_ssl", "rabbitmq_auth_backend_ldap.use_ssl",
+    [{datatype, {enum, [true, false]}}]}.
+
+%% Connect to the LDAP server using StartTLS
+%%
+%% {use_starttls, false},
+
+{mapping, "auth_ldap.use_starttls", "rabbitmq_auth_backend_ldap.use_starttls",
+    [{datatype, {enum, [true, false]}}]}.
+
+
+%% TLS options
+
+{mapping, "auth_ldap.ssl_options", "rabbitmq_auth_backend_ldap.ssl_options", [
+    {datatype, {enum, [none]}}
+]}.
+
+{translation, "rabbitmq_auth_backend_ldap.ssl_options",
+fun(Conf) ->
+    case cuttlefish:conf_get("auth_ldap.ssl_options", Conf, undefined) of
+        none -> [];
+        _    -> cuttlefish:invalid("Invalid auth_ldap.ssl_options")
+    end
+end}.
+
+{mapping, "auth_ldap.ssl_options.verify", "rabbitmq_auth_backend_ldap.ssl_options.verify", [
+    {datatype, {enum, [verify_peer, verify_none]}}]}.
+
+{mapping, "auth_ldap.ssl_options.fail_if_no_peer_cert", "rabbitmq_auth_backend_ldap.ssl_options.fail_if_no_peer_cert", [
+    {datatype, {enum, [true, false]}}]}.
+
+{mapping, "auth_ldap.ssl_options.cacertfile", "rabbitmq_auth_backend_ldap.ssl_options.cacertfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "auth_ldap.ssl_options.certfile", "rabbitmq_auth_backend_ldap.ssl_options.certfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "auth_ldap.ssl_options.cacerts.$name", "rabbitmq_auth_backend_ldap.ssl_options.cacerts",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_ldap.ssl_options.cacerts",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("auth_ldap.ssl_options.cacerts", Conf),
+    [ list_to_binary(V) || {_, V} <- Settings ]
+end}.
+
+{mapping, "auth_ldap.ssl_options.cert", "rabbitmq_auth_backend_ldap.ssl_options.cert",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_ldap.ssl_options.cert",
+fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("auth_ldap.ssl_options.cert", Conf))
+end}.
+
+{mapping, "auth_ldap.ssl_options.client_renegotiation", "rabbitmq_auth_backend_ldap.ssl_options.client_renegotiation",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "auth_ldap.ssl_options.crl_check", "rabbitmq_auth_backend_ldap.ssl_options.crl_check",
+    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+
+{mapping, "auth_ldap.ssl_options.depth", "rabbitmq_auth_backend_ldap.ssl_options.depth",
+    [{datatype, integer}, {validators, ["byte"]}]}.
+
+{mapping, "auth_ldap.ssl_options.dh", "rabbitmq_auth_backend_ldap.ssl_options.dh",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_ldap.ssl_options.dh",
+fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("auth_ldap.ssl_options.dh", Conf))
+end}.
+
+{mapping, "auth_ldap.ssl_options.dhfile", "rabbitmq_auth_backend_ldap.ssl_options.dhfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "auth_ldap.ssl_options.honor_cipher_order", "rabbitmq_auth_backend_ldap.ssl_options.honor_cipher_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "auth_ldap.ssl_options.honor_ecc_order", "rabbitmq_auth_backend_ldap.ssl_options.honor_ecc_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "auth_ldap.ssl_options.key.RSAPrivateKey", "rabbitmq_auth_backend_ldap.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "auth_ldap.ssl_options.key.DSAPrivateKey", "rabbitmq_auth_backend_ldap.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "auth_ldap.ssl_options.key.PrivateKeyInfo", "rabbitmq_auth_backend_ldap.ssl_options.key",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_ldap.ssl_options.key",
+fun(Conf) ->
+    case cuttlefish_variable:filter_by_prefix("auth_ldap.ssl_options.key", Conf) of
+        [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
+        _ -> undefined
+    end
+end}.
+
+{mapping, "auth_ldap.ssl_options.keyfile", "rabbitmq_auth_backend_ldap.ssl_options.keyfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "auth_ldap.ssl_options.log_alert", "rabbitmq_auth_backend_ldap.ssl_options.log_alert",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "auth_ldap.ssl_options.password", "rabbitmq_auth_backend_ldap.ssl_options.password",
+    [{datatype, string}]}.
+
+{mapping, "auth_ldap.ssl_options.psk_identity", "rabbitmq_auth_backend_ldap.ssl_options.psk_identity",
+    [{datatype, string}]}.
+
+{mapping, "auth_ldap.ssl_options.reuse_sessions", "rabbitmq_auth_backend_ldap.ssl_options.reuse_sessions",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "auth_ldap.ssl_options.secure_renegotiate", "rabbitmq_auth_backend_ldap.ssl_options.secure_renegotiate",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "auth_ldap.ssl_options.versions.$version", "rabbitmq_auth_backend_ldap.ssl_options.versions",
+    [{datatype, atom}]}.
+
+{translation, "rabbitmq_auth_backend_ldap.ssl_options.versions",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("auth_ldap.ssl_options.versions", Conf),
+    [ V || {_, V} <- Settings ]
+end}.

--- a/test/config_schema_SUITE_data/certs/cacert.pem
+++ b/test/config_schema_SUITE_data/certs/cacert.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/test/config_schema_SUITE_data/certs/cert.pem
+++ b/test/config_schema_SUITE_data/certs/cert.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/test/config_schema_SUITE_data/certs/key.pem
+++ b/test/config_schema_SUITE_data/certs/key.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
@@ -121,4 +121,129 @@
   "auth_ldap.other_bind.user_dn = username
    auth_ldap.other_bind.password = password",
   [{rabbitmq_auth_backend_ldap,[{other_bind,{"username","password"}}]}],
-  [rabbitmq_auth_backend_ldap]}].
+  [rabbitmq_auth_backend_ldap]},
+
+ {ssl_options,
+  "auth_ldap.use_ssl                          = true
+   auth_ldap.ssl_options.cacertfile           = test/config_schema_SUITE_data/certs/cacert.pem
+   auth_ldap.ssl_options.certfile             = test/config_schema_SUITE_data/certs/cert.pem
+   auth_ldap.ssl_options.keyfile              = test/config_schema_SUITE_data/certs/key.pem
+   auth_ldap.ssl_options.verify               = verify_peer
+   auth_ldap.ssl_options.fail_if_no_peer_cert = true",
+  [{rabbitmq_auth_backend_ldap, [
+        {use_ssl, true},
+        {ssl_options,
+            [{cacertfile, "test/config_schema_SUITE_data/certs/cacert.pem"},
+             {certfile,   "test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,    "test/config_schema_SUITE_data/certs/key.pem"},
+             {verify,               verify_peer},
+             {fail_if_no_peer_cert, true}]}
+   ]}],
+  [rabbitmq_auth_backend_ldap]},
+
+ {ssl_options_verify_peer,
+  "auth_ldap.use_ssl = true
+   auth_ldap.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   auth_ldap.ssl_options.certfile = test/config_schema_SUITE_data/certs/cert.pem
+   auth_ldap.ssl_options.keyfile = test/config_schema_SUITE_data/certs/key.pem
+   auth_ldap.ssl_options.verify = verify_peer
+   auth_ldap.ssl_options.fail_if_no_peer_cert = false",
+  [{rabbitmq_auth_backend_ldap,
+       [{use_ssl, true},
+        {ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {verify,verify_peer},
+             {fail_if_no_peer_cert,false}]}]}],
+  []},
+ {ssl_options_password,
+  "auth_ldap.use_ssl = true
+   auth_ldap.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   auth_ldap.ssl_options.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   auth_ldap.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   auth_ldap.ssl_options.password   = t0p$3kRe7",
+  [{rabbitmq_auth_backend_ldap,
+       [{use_ssl, true},
+        {ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {password,"t0p$3kRe7"}]}]}],
+  []},
+ {ssl_options_tls_versions,
+  "auth_ldap.use_ssl = true
+   auth_ldap.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   auth_ldap.ssl_options.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   auth_ldap.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   auth_ldap.ssl_options.versions.tls1_2 = tlsv1.2
+   auth_ldap.ssl_options.versions.tls1_1 = tlsv1.1",
+  [],
+  [{rabbitmq_auth_backend_ldap,
+       [{ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {versions,['tlsv1.2','tlsv1.1']}]},
+        {use_ssl, true}]}],
+  []},
+ {ssl_options_depth,
+  "auth_ldap.use_ssl = true
+   auth_ldap.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   auth_ldap.ssl_options.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   auth_ldap.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   auth_ldap.ssl_options.depth      = 2
+   auth_ldap.ssl_options.verify     = verify_peer
+   auth_ldap.ssl_options.fail_if_no_peer_cert = false",
+  [{rabbitmq_auth_backend_ldap,
+       [{use_ssl, true},
+        {ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {depth,2},
+             {verify,verify_peer},
+             {fail_if_no_peer_cert,false}]}]}],
+  []},
+ {ssl_options_honor_cipher_order,
+  "auth_ldap.use_ssl = true
+   auth_ldap.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   auth_ldap.ssl_options.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   auth_ldap.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   auth_ldap.ssl_options.depth      = 2
+   auth_ldap.ssl_options.verify     = verify_peer
+   auth_ldap.ssl_options.fail_if_no_peer_cert = false
+   auth_ldap.ssl_options.honor_cipher_order   = true",
+  [{rabbitmq_auth_backend_ldap,
+       [{use_ssl, true},
+        {ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {depth,2},
+             {verify,verify_peer},
+             {fail_if_no_peer_cert, false},
+             {honor_cipher_order, true}]}]}],
+  []},
+ {ssl_options_honor_ecc_order,
+  "auth_ldap.use_ssl = true
+   auth_ldap.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   auth_ldap.ssl_options.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   auth_ldap.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   auth_ldap.ssl_options.depth      = 2
+   auth_ldap.ssl_options.verify     = verify_peer
+   auth_ldap.ssl_options.fail_if_no_peer_cert = false
+   auth_ldap.ssl_options.honor_ecc_order      = true",
+  [{rabbitmq_auth_backend_ldap,
+       [{use_ssl, true},
+        {ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {depth,2},
+             {verify,verify_peer},
+             {fail_if_no_peer_cert, false},
+             {honor_ecc_order, true}]}]}],
+  []}
+
+].


### PR DESCRIPTION
## Proposed Changes

This makes it possible to configure TLS options via new style config, much like
we do for the server. I dropped a couple of options that make no sense for LDAP clients.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #88)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #88.

[#156159684]