### PR TITLE
Retry LDAP operations on eldap reported connection errors

### DIFF
--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -480,7 +480,7 @@ with_ldap({ok, Creds}, Fun, Servers) ->
 with_login(Creds, Servers, Opts, Fun) ->
     with_login(Creds, Servers, Opts, Fun, ?LDAP_OPERATION_RETRIES).
 with_login(_Creds, _Servers, _Opts, _Fun, 0 = _RetriesLeft) ->
-    ?L1("failed to perform an LDAP operation: exhausted all retries", []),
+    rabbit_log:warning("LDAP failed to perform an operation. TCP connection to a LDAP server was closed or otherwise defunct. Exhausted all retries.~n"),
     {error, ldap_connect_error};
 with_login(Creds, Servers, Opts, Fun, RetriesLeft) ->
     case get_or_create_conn(Creds == anon, Servers, Opts) of

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -38,6 +38,8 @@
 -define(SCRUBBED_CREDENTIAL,  "xxxx").
 -define(RESOURCE_ACCESS_QUERY_VARIABLES, [username, user_dn, vhost, resource, name, permission]).
 
+-define(LDAP_OPERATION_RETRIES, 10).
+
 -import(rabbit_misc, [pget/2]).
 
 -record(impl, { user_dn, password }).
@@ -476,7 +478,7 @@ with_ldap({ok, Creds}, Fun, Servers) ->
       end, reuse).
 
 with_login(Creds, Servers, Opts, Fun) ->
-    with_login(Creds, Servers, Opts, Fun, 5).
+    with_login(Creds, Servers, Opts, Fun, ?LDAP_OPERATION_RETRIES).
 with_login(_Creds, _Servers, _Opts, _Fun, 0 = _RetriesLeft) ->
     ?L1("failed to perform an LDAP operation: exhausted all retries", []),
     {error, ldap_connect_error};

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -535,6 +535,9 @@ call_ldap_fun(Fun, LDAP, UserDN) ->
         {error, ldap_closed} ->
             %% LDAP connection was close, let with_login/5 retry
             {error, ldap_closed};
+        {error, {gen_tcp_error, E}} ->
+            %% ditto
+            {error, {gen_tcp_error, E}};
         {error, E} ->
             ?L1("evaluate error: ~s ~p", [scrub_dn(UserDN, env(log)), E]),
             {error, ldap_evaluate_error};


### PR DESCRIPTION
## Proposed Changes

This makes the plugin retry up to 10 times when eldap reports a connection or gen_tcp error.

Testing this is painful. Here's one scenario:

 * `vagrant up` to launch a VM with OpenLDAP for tests
 * `vagrant ssh`
 * In a different tab, start a node with `RABBITMQ_ALLOW_INPUT=1` this plugin enabled and e.g. the [following config](https://gist.github.com/michaelklishin/c16738d169465594bb25e22f1e74fa1f)
 * `gmake test-build` in the plugin repo to compile test modules
 * In the node tab, hit Enter a few times to enter a shell
 * `code:add_path("/path/to/umbrella/deps/rabbitmq_auth_backend_ldap/test/").`
 * `rabbit_ldap_seed:seed({"localhost", 3890}).` will seed the test data
 * Try logging in as `Alice` with password `password` (whether it fails or not, it should communicate successfully to the LDAP server).
 * In the VM, block traffic on the LDAP port: `sudo iptables -A INPUT -p tcp --destination-port 389 -j DROP`
 * Retry logging in while tailing node logs. At some point you will see messages about retries and retry exhaustion.
 * Unblock port traffic: `sudo iptables -D INPUT -p tcp --destination-port 389 -j DROP`
 * Try logging in as Alice again, regardless of whether it will succeed, the plugin will successfully open a new connection and use it, therefore demonstrating a recovery

I couldn't find a way to catch a succeeding retry in the moment because we do not inject any delays between retries: this code is executed on the hot code path.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #90, #82)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #90, references #82.
[#156324176]
