### PR TITLE
Accept authentication context in user_login_authorization/2

### DIFF
--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -24,7 +24,7 @@
 -behaviour(rabbit_authn_backend).
 -behaviour(rabbit_authz_backend).
 
--export([user_login_authentication/2, user_login_authorization/1,
+-export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/3, check_topic_access/4]).
 
 -export([get_connections/0]).
@@ -89,8 +89,8 @@ user_login_authentication(Username, AuthProps) when is_list(AuthProps) ->
 user_login_authentication(Username, AuthProps) ->
     exit({unknown_auth_props, Username, AuthProps}).
 
-user_login_authorization(Username) ->
-    case user_login_authentication(Username, []) of
+user_login_authorization(Username, AuthProps) ->
+    case user_login_authentication(Username, AuthProps) of
         {ok, #auth_user{impl = Impl, tags = Tags}} -> {ok, Impl, Tags};
         Else                                       -> Else
     end.


### PR DESCRIPTION
## Proposed Changes

This propagates authentication context (properties) to `user_login_authorization/2`.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #1633)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-server#1633.

[#158805410]
