### PR TITLE
Tokenize NetBIOS logins on the backslash character

### DIFF
--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -98,9 +98,10 @@ user_login_authorization(Username, AuthProps) ->
 check_vhost_access(User = #auth_user{username = Username,
                                      impl     = #impl{user_dn = UserDN}},
                    VHost, _Sock) ->
+    ADArgs = get_active_directory_args(Username),
     Args = [{username, Username},
             {user_dn,  UserDN},
-            {vhost,    VHost}],
+            {vhost,    VHost}] ++ ADArgs,
     ?L("CHECK: ~s for ~s", [log_vhost(Args), log_user(User)]),
     R = evaluate_ldap(env(vhost_access_query), Args, User),
     ?L("DECISION: ~s for ~s: ~p",
@@ -111,12 +112,13 @@ check_resource_access(User = #auth_user{username = Username,
                                         impl     = #impl{user_dn = UserDN}},
                       #resource{virtual_host = VHost, kind = Type, name = Name},
                       Permission) ->
+    ADArgs = get_active_directory_args(Username),
     Args = [{username,   Username},
             {user_dn,    UserDN},
             {vhost,      VHost},
             {resource,   Type},
             {name,       Name},
-            {permission, Permission}],
+            {permission, Permission}] ++ ADArgs,
     ?L("CHECK: ~s for ~s", [log_resource(Args), log_user(User)]),
     R = evaluate_ldap(env(resource_access_query), Args, User),
     ?L("DECISION: ~s for ~s: ~p",
@@ -129,12 +131,13 @@ check_topic_access(User = #auth_user{username = Username,
                    Permission,
                    Context) ->
     OptionsArgs = topic_context_as_options(Context, undefined),
+    ADArgs = get_active_directory_args(Username),
     Args = [{username,   Username},
             {user_dn,    UserDN},
             {vhost,      VHost},
             {resource,   Resource},
             {name,       Name},
-            {permission, Permission}] ++ OptionsArgs,
+            {permission, Permission}] ++ OptionsArgs ++ ADArgs,
     ?L("CHECK: ~s for ~s", [log_resource(Args), log_user(User)]),
     R = evaluate_ldap(env(topic_access_query), Args, User),
     ?L("DECISION: ~s for ~s: ~p",
@@ -705,9 +708,10 @@ do_login(Username, PrebindUserDN, Password, VHost, LDAP) ->
 do_tag_queries(Username, UserDN, User, VHost, LDAP) ->
     {ok, [begin
               ?L1("CHECK: does ~s have tag ~s?", [Username, Tag]),
-              R = evaluate(Q, [{username, Username},
-                               {user_dn,  UserDN} | vhost_if_defined(VHost)],
-                           User, LDAP),
+              VhostArgs = vhost_if_defined(VHost),
+              ADArgs = get_active_directory_args(Username),
+              EvalArgs = [{username, Username}, {user_dn, UserDN}] ++ VhostArgs ++ ADArgs,
+              R = evaluate(Q, EvalArgs, User, LDAP),
               ?L1("DECISION: does ~s have tag ~s? ~p",
                   [Username, Tag, R]),
               {Tag, R}
@@ -752,7 +756,8 @@ dn_lookup(Username, LDAP) ->
     end.
 
 fill_user_dn_pattern(Username) ->
-    fill(env(user_dn_pattern), [{username, Username}]).
+    ADArgs = get_active_directory_args(Username),
+    fill(env(user_dn_pattern), [{username, Username}] ++ ADArgs).
 
 creds(User) -> creds(User, env(other_bind)).
 
@@ -825,6 +830,15 @@ fill(Fmt, Args) ->
     R = rabbit_auth_backend_ldap_util:fill(Fmt, Args),
     ?L2("template result: \"~s\"", [R]),
     R.
+
+get_active_directory_args([ADUser, ADDomain]) ->
+    [{ad_user, ADUser}, {ad_domain, ADDomain}];
+get_active_directory_args(Parts) when is_list(Parts) ->
+    [];
+get_active_directory_args(Username) when is_binary(Username) ->
+    % If Username is in Domain\User format, provide additional fill
+    % template arguments
+    get_active_directory_args(binary:split(Username, <<"\\">>, [trim_all])).
 
 log_result({ok, #auth_user{}}) -> ok;
 log_result(true)               -> ok;

--- a/src/rabbit_auth_backend_ldap_util.erl
+++ b/src/rabbit_auth_backend_ldap_util.erl
@@ -16,7 +16,7 @@
 
 -module(rabbit_auth_backend_ldap_util).
 
--export([fill/2]).
+-export([fill/2, get_active_directory_args/1]).
 
 fill(Fmt, []) ->
     binary_to_list(iolist_to_binary(Fmt));
@@ -32,3 +32,11 @@ to_repl([$\\ | T])           -> [$\\, $\\ | to_repl(T)];
 to_repl([$&  | T])           -> [$\\, $&  | to_repl(T)];
 to_repl([H   | T])           -> [H        | to_repl(T)].
 
+get_active_directory_args([ADDomain, ADUser]) ->
+    [{ad_domain, ADDomain}, {ad_user, ADUser}];
+get_active_directory_args(Parts) when is_list(Parts) ->
+    [];
+get_active_directory_args(Username) when is_binary(Username) ->
+    % If Username is in Domain\User format, provide additional fill
+    % template arguments
+    get_active_directory_args(binary:split(Username, <<"\\">>, [trim_all])).

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -23,7 +23,8 @@
 
 all() ->
     [
-     fill
+     fill,
+     ad_fill
     ].
 
 fill(_Config) ->
@@ -38,4 +39,18 @@ fill(_Config) ->
     F("x${usernamex",  [{username,  "ab"}],     "x${usernamex"),
     F("x${username}x", [{username,  "a\\b"}],   "xa\\bx"),
     F("x${username}x", [{username,  "a&b"}],    "xa&bx"),
+    ok.
+
+ad_fill(_Config) ->
+    F = fun(Fmt, Args, Res) ->
+                ?assertEqual(Res, rabbit_auth_backend_ldap_util:fill(Fmt, Args))
+        end,
+
+    U0 = <<"ADDomain\\ADUser">>,
+    A0 = rabbit_auth_backend_ldap_util:get_active_directory_args(U0),
+    F("x-${ad_domain}-x-${ad_user}-x", A0, "x-ADDomain-x-ADUser-x"),
+
+    U1 = <<"ADDomain\\ADUser\\Extra">>,
+    A1 = rabbit_auth_backend_ldap_util:get_active_directory_args(U1),
+    F("x-${ad_domain}-x-${ad_user}-x", A1, "x-ADDomain-x-ADUser\\Extra-x"),
     ok.


### PR DESCRIPTION
Fixes #98

This allows `Domain\User` to be used in templates via `${ad_domain}` and `{$ad_user}`

See the following discussion: https://groups.google.com/d/topic/rabbitmq-users/mK87YcRy4vQ/discussion