### PR TITLE
Fix LDAP match vs multivalue attributes.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,76 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
 Vagrant.configure(2) do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "ubuntu/trusty64"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 389, host: 3890
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: "sudo apt-get -y update"
   config.vm.provision "file", source: "example", destination: "~/example"
   config.vm.provision "shell", inline: "/bin/sh /home/vagrant/example/setup.sh"
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   sudo apt-get update
-  #   sudo apt-get --yes install slapd ldap-utils
-  #   sleep(1)
-
-  # SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = 'ubuntu/xenial64'
   config.vm.network "forwarded_port", guest: 389, host: 3890
   config.vm.provision "shell", inline: "sudo apt-get -y update"
   config.vm.provision "file", source: "example", destination: "~/example"

--- a/test/rabbit_ldap_seed.erl
+++ b/test/rabbit_ldap_seed.erl
@@ -60,7 +60,8 @@ people() ->
       johndoe(),
       alice(),
       peter(),
-      carol()
+      carol(),
+      jimmy()
     ].
 
 groups() ->
@@ -183,6 +184,15 @@ carol() ->
                        "person"]},
       {"loginShell", ["/bin/bash"]},
       {"userPassword", ["password"]}]}.
+
+% rabbitmq/rabbitmq-auth-backend-ldap#100
+jimmy() ->
+    {"cn=Jimmy,ou=people,dc=rabbitmq,dc=com",
+     [{"objectClass", ["person"]},
+      {"cn", ["Jimmy"]},
+      {"sn", ["Makes"]},
+      {"userPassword", ["password"]},
+      {"description", ["^RMQ-foobar", "^RMQ-.*$"]}]}.
 
 add(H, {A, B}) ->
     ok = eldap:add(H, A, B).


### PR DESCRIPTION
## Proposed Changes

Make match work when LDAP attribute queries return a lists of strings, as happens for multi-value attributes.

The previous code tries to do weird things by exchanging the arguments being put in to re:run(). Bidirectional match might seem to work when the regular expression is just a couple of plaintexts, but is actually really wrong and also causes confusing log messages when your RE-expression end up in the string matching. 

Secondly it seemed to handle multi-valued LDAP results by concatenating them into strings like "First_item;second_item" which makes for very interesting results when you try to match against R.Es like ^read$

This change guards against cases when the LDAP query evaluates to a list and fallbacks to regular do_match when the arguments aren't lists of strings.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #100)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

