### PR TITLE
Add user_bind_pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PROJECT_MOD = rabbit_auth_backend_ldap_app
 define PROJECT_ENV
 [
 	    {servers,               undefined},
+	    {user_bind_pattern,     none},
 	    {user_dn_pattern,       "$${username}"},
 	    {dn_lookup_attribute,   none},
 	    {dn_lookup_base,        none},

--- a/src/rabbit_auth_backend_ldap.erl
+++ b/src/rabbit_auth_backend_ldap.erl
@@ -79,7 +79,7 @@ user_login_authentication(Username, AuthProps) when is_list(AuthProps) ->
                     prebind -> UserDN = username_to_dn_prebind(Username),
                                with_ldap({ok, {UserDN, PW}},
                                          login_fun(Username, UserDN, PW, AuthProps));
-                    _       -> with_ldap({ok, {fill_user_dn_pattern(Username), PW}},
+                    _       -> with_ldap({ok, {simple_bind_fill_pattern(Username), PW}},
                                          login_fun(Username, unknown, PW, AuthProps))
                 end,
             ?L("DECISION: login for ~s: ~p", [Username, log_result(R)]),
@@ -758,6 +758,15 @@ dn_lookup(Username, LDAP) ->
 fill_user_dn_pattern(Username) ->
     ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
     fill(env(user_dn_pattern), [{username, Username}] ++ ADArgs).
+
+simple_bind_fill_pattern(Username) ->
+    simple_bind_fill_pattern(env(user_bind_pattern), Username).
+
+simple_bind_fill_pattern(none, Username) ->
+    fill_user_dn_pattern(Username);
+simple_bind_fill_pattern(Pattern, Username) ->
+    ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
+    fill(Pattern, [{username, Username}] ++ ADArgs).
 
 creds(User) -> creds(User, env(other_bind)).
 


### PR DESCRIPTION
This allows using a different pattern during the "simple bind" phase. If `user_bind_pattern` is defined, it is used, otherwise fall back to `user_dn_pattern`.

For instance, in environments where the NetBIOS name is used for the simple bind (`Domain\User`) the `user_bind_pattern` can be set to `${username}` and then `user_dn_pattern` can be set to `${ad_user}` so that only `User` is matched against `sAMAccountName`.

Related to #98 and #99