### PR TITLE
replace rabbit_log by rabbit_log_ldap

### DIFF
--- a/src/rabbit_auth_backend_ldap_app.erl
+++ b/src/rabbit_auth_backend_ldap_app.erl
@@ -36,7 +36,7 @@ start(_Type, _StartArgs) ->
     {ok, Backends} = application:get_env(rabbit, auth_backends),
     case configured(rabbit_auth_backend_ldap, Backends) of
         true  -> ok;
-        false -> rabbit_log:warning(
+        false -> rabbit_log_ldap:warning(
                    "LDAP plugin loaded, but rabbit_auth_backend_ldap is not "
                    "in the list of auth_backends. LDAP auth will not work.~n")
     end,


### PR DESCRIPTION
This PR allow to setup external sink for ldap, so you can use different log file for ldap messages.
Now a lot of messages from ldap are accumulated in default log, so it is difficult to search some important
messages in default log because of huge lines of ldap logs