### PR TITLE
Propagate protocol-specific context

### DIFF
--- a/src/rabbit_auth_backend_ldap_util.erl
+++ b/src/rabbit_auth_backend_ldap_util.erl
@@ -30,7 +30,8 @@ to_repl(V) when is_binary(V) -> to_repl(binary_to_list(V));
 to_repl([])                  -> [];
 to_repl([$\\ | T])           -> [$\\, $\\ | to_repl(T)];
 to_repl([$&  | T])           -> [$\\, $&  | to_repl(T)];
-to_repl([H   | T])           -> [H        | to_repl(T)].
+to_repl([H   | T])           -> [H        | to_repl(T)];
+to_repl(_)                   -> []. % fancy variables like peer IP are just ignored
 
 get_active_directory_args([ADDomain, ADUser]) ->
     [{ad_domain, ADDomain}, {ad_user, ADUser}];


### PR DESCRIPTION
Information like MQTT client ID is now propagated to the LDAP registry
for all authentication and authorization functions.

References rabbitmq/rabbitmq-server#1767