### PR TITLE
Add warning messages when configuration values do not make sense

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && \
+    apt-get -y upgrade
+
+RUN apt-get -y install sudo
+
+COPY ./example /ci
+ADD --chown=664 ./example/setup.sh /ci/setup.sh
+
+RUN ls /ci
+
+RUN /ci/setup.sh
+
+ENTRYPOINT service slapd start && service slapd status && bash

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PROJECT = rabbitmq_auth_backend_ldap
 PROJECT_DESCRIPTION = RabbitMQ LDAP Authentication Backend
 PROJECT_MOD = rabbit_auth_backend_ldap_app
 
+# Note:
+# Use of these default values in calls to get_expected_env_str/2
 define PROJECT_ENV
 [
 	    {servers,               undefined},

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,16 @@
 
 ## The OpenLDAP Dependency
 
+There are two ways of setting up an OpenLDAP node with a seed expectd
+by the test suite:
+
+ * Vagrant
+ * Docker
+
+The test setup will seed the LDAP database with the required objects.
+
+### With Vagrant
+
 If you have [Vagrant](https://www.vagrantup.com) installed you
 can simply `vagrant up` from the root of the project directory.
 This will start a vagrant box with OpenLDAP running, accessible
@@ -14,12 +24,26 @@ Alternatively run OpenLDAP locally on a local port specified via the `LDAP_PORT`
 The setup script currently needs to be executed between test suite runs,
 too.
 
-The test setup will seed the LDAP database with the required objects.
+### With Docker
+
+First build the image:
+
+``` sh
+docker build -t rabbitmq_auth_backend_ldap .
+```
+
+Run it with
+
+``` sh
+docker run -p 3890:389 -i -t rabbitmq_auth_backend_ldap
+```
 
 ## Running All Suites
 
 As with all other RabbitMQ subprojects,
 
-    make tests
+``` sh
+make tests
+```
 
 will run all test suites.

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -9,8 +9,11 @@ slapd    slapd/internal/adminpw    password openstack
 slapd    slapd/password1    password    openstack
 slapd    slapd/backend    select    BDB
 " | sudo debconf-set-selections
-sudo apt-get --yes install slapd ldap-utils
-sleep 1
+sudo apt-get --yes install dialog slapd ldap-utils
+sleep 5
+
+sudo service slapd start
+sudo service slapd status
 
 DIR=$(dirname $0)
 


### PR DESCRIPTION
To test, use the following `rabbitmq.config` file. First, leave both `dn_lookup_base` and `dn_lookup_attribute` commented out (unset), and you'll see a warning message stating that DN lookup bind won't happen. Then, set `dn_lookup_attribute` to a value and leave `dn_lookup_base` set to `none`. In that case, you'll see a syntax error (`{error,invalidDNSyntax}`) whereas previously you'd see a nasty crash like this -

```
{{:error, {{:badmatch, {:error, {:asn1, {:function_clause, [{:ELDAPv3, :encode_restricted_string, [:none, [<<4>>]],
```

```
[
    {rabbit, [
        {auth_backends, [rabbit_auth_backend_ldap]},
        {loopback_users, []},
        {log, [
            {console, [{enabled, true}, %% log.console
                       {level, debug}    %% log.console.level
            ]}
        ]}
    ]},
    {rabbitmq_auth_backend_ldap, [
        {log,                 network_unsafe},
        {servers,             ["dsch-win"]},
        {dn_lookup_attribute, "userPrincipalName"},
        %% {dn_lookup_base,      "OU=users,DC=bakken,DC=io"},
        %% {dn_lookup_attribute, 'none'},
        {dn_lookup_base,      'none'},
        {dn_lookup_bind,      {"CN=Reader Admin,OU=users,DC=bakken,DC=io", "admin1234"}},
        {tag_queries,         [
            {administrator, {in_group, "CN=rabbitmq-users,OU=groups,DC=bakken,DC=io"}},
            {management, {constant, true}}
        ]}
    ]}
].
```